### PR TITLE
Suggested changes

### DIFF
--- a/Engine/Enemy.cpp
+++ b/Engine/Enemy.cpp
@@ -1,6 +1,5 @@
 #include "Enemy.h"
 
-Enemy::Enemy(){}
 
 Enemy::Enemy( Vector Position, int Width, int Height)
 	:

--- a/Engine/Enemy.h
+++ b/Engine/Enemy.h
@@ -5,7 +5,7 @@
 class Enemy : public Entity
 {
 public:
-	Enemy(){}
+	Enemy() = default;
 	Enemy( Vector Position, int Width, int Height);
 	~Enemy();
 };

--- a/Engine/Entity.cpp
+++ b/Engine/Entity.cpp
@@ -1,6 +1,6 @@
 #include "Entity.h"
 
-Entity::Entity(){}
+
 
 Entity::Entity( Vector Position, int Width, int Height)
 	:

--- a/Engine/Entity.h
+++ b/Engine/Entity.h
@@ -6,7 +6,7 @@
 class Entity
 {
 public:
-	Entity();
+	Entity() = default;
 	Entity( Vector Position, int Width, int Height);
 	~Entity();
 	void Update();

--- a/Engine/EntityMovement.cpp
+++ b/Engine/EntityMovement.cpp
@@ -1,6 +1,6 @@
 #include "EntityMovement.h"
+#include "GameObject.h"
 
-EntityMovement::EntityMovement(){}
 
 EntityMovement::EntityMovement( GameObject &Object )
 	:

--- a/Engine/EntityMovement.h
+++ b/Engine/EntityMovement.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "GameObject.h"
+class GameObject;
 
 class EntityMovement
 {
 public:
-	EntityMovement();
 	EntityMovement( GameObject &Object );
 	void MoveProjectile();
 	void MoveShip();

--- a/Engine/GameObject.cpp
+++ b/Engine/GameObject.cpp
@@ -1,6 +1,5 @@
 #include "GameObject.h"
 
-GameObject::GameObject(){}
 
 GameObject::GameObject( MainWindow &Wnd )
 	:

--- a/Engine/GameObject.h
+++ b/Engine/GameObject.h
@@ -12,7 +12,6 @@
 class GameObject
 {
 public:
-	GameObject();
 	GameObject( MainWindow &Wnd);
 
 public:

--- a/Engine/Input.cpp
+++ b/Engine/Input.cpp
@@ -1,6 +1,5 @@
 #include "Input.h"
-
-Input::Input(){}
+#include "GameObject.h"
 
 Input::Input( GameObject &Object )
 	:

--- a/Engine/Input.h
+++ b/Engine/Input.h
@@ -1,11 +1,10 @@
 #pragma once
-#include "GameObject.h"
 
+class GameObject;
 
 class Input
 {
 public:
-	Input();
 	Input( GameObject &Object );
 
 	void Update();

--- a/Engine/Upgrade.cpp
+++ b/Engine/Upgrade.cpp
@@ -1,6 +1,6 @@
 #include "Upgrade.h"
+#include "GameObject.h"
 
-Upgrade::Upgrade(){}
 
 Upgrade::Upgrade( GameObject &GameObject )
 	:

--- a/Engine/Upgrade.h
+++ b/Engine/Upgrade.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "GameObject.h"
+class GameObject;
 
 class Upgrade
 {
 public:
-	Upgrade();
 	Upgrade( GameObject &GameObject );
 	
 public:


### PR DESCRIPTION
…reate default constructor, can just declare = default; if you need one, if not then just remove all together.

Forward declare GameObject in EntityMovement.h
Include GameObject.h in EntityMovement.cpp
GameObject stores a reference, so shouldn't make a default constructor
EntityMovement stores a reference, so shouldn't make a default constructor
Input stores a reference, so shouldn't make a default constructor
Upgrade stores a reference, so shouldn't make a default constructor